### PR TITLE
make http status depends on checker error

### DIFF
--- a/health.go
+++ b/health.go
@@ -133,6 +133,12 @@ func (h *health) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		code = http.StatusServiceUnavailable
 	}
 
+	for _, checkResult := range status.HealthCheckers {
+		if checkResult.Error != nil {
+			code = http.StatusServiceUnavailable
+		}
+	}
+
 	w.WriteHeader(code)
 	w.Write(bytes)
 }

--- a/health.go
+++ b/health.go
@@ -136,6 +136,7 @@ func (h *health) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, checkResult := range status.HealthCheckers {
 		if checkResult.Error != nil {
 			code = http.StatusServiceUnavailable
+			break
 		}
 	}
 

--- a/health_test.go
+++ b/health_test.go
@@ -149,3 +149,22 @@ func TestShutdown(t *testing.T) {
 		t.Errorf("Expect %d and got %d", http.StatusServiceUnavailable, rec.Result().StatusCode)
 	}
 }
+
+func TestServeHTTPCheckerFailure(t *testing.T) {
+	h := New("service_test", Options{})
+	h.RegisterChecker("checker1", &mockChecker{err: errors.New("Service unreachable")})
+
+	req, err := http.NewRequest("GET", "localhost/health", nil)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Result().StatusCode != 503 {
+		t.Errorf("Expect 503 and got %d", rec.Result().StatusCode)
+	}
+}


### PR DESCRIPTION
If a custom checker is added which always fail, the health check still return http status 200 while I believe it should return http status 503.

There are two changes : A test highlighting the issue and the fix.